### PR TITLE
Allow non-MP3 source files to get transcoded

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -64,7 +64,7 @@ class Emby(CommonPlaySkill):
         """
         # setup audio service
         self.audio_service = AudioService(self.bus)
-        self.audio_service.play(data[phrase], data['utterance'])
+        self.audio_service.play(data[phrase])
 
     def CPS_match_query_phrase(self, phrase):
         """ This method responds whether the skill can play the input phrase.

--- a/__init__.py
+++ b/__init__.py
@@ -64,7 +64,7 @@ class Emby(CommonPlaySkill):
         """
         # setup audio service
         self.audio_service = AudioService(self.bus)
-        self.audio_service.play(data[phrase])
+        self.audio_service.play(data[phrase], data['utterance'])
 
     def CPS_match_query_phrase(self, phrase):
         """ This method responds whether the skill can play the input phrase.

--- a/__init__.py
+++ b/__init__.py
@@ -46,7 +46,7 @@ class Emby(CommonPlaySkill):
             # setup audio service and play
             self.audio_service = AudioService(self.bus)
             self.speak_playing(intent)
-            self.audio_service.play(songs)
+            self.audio_service.play(songs, message.data['utterance'])
 
     def speak_playing(self, media):
         data = dict()

--- a/emby_client.py
+++ b/emby_client.py
@@ -201,4 +201,4 @@ class MediaItemType(Enum):
         for item_type in MediaItemType:
             if item_type.value == enum_string:
                 return item_type
-        return OTHER
+        return MediaItemType.OTHER

--- a/emby_client.py
+++ b/emby_client.py
@@ -20,7 +20,7 @@ AUTH_USERNAME_KEY = "Username"
 AUTH_PASSWORD_KEY = "Pw"
 
 # query param constants
-AUDIO_STREAM = "stream?static=true"
+AUDIO_STREAM = "stream.mp3"
 API_KEY = "api_key="
 
 

--- a/emby_client.py
+++ b/emby_client.py
@@ -20,7 +20,7 @@ AUTH_USERNAME_KEY = "Username"
 AUTH_PASSWORD_KEY = "Pw"
 
 # query param constants
-AUDIO_STREAM = "stream.mp3"
+AUDIO_STREAM = "stream?static=true"
 API_KEY = "api_key="
 
 

--- a/emby_client.py
+++ b/emby_client.py
@@ -20,7 +20,7 @@ AUTH_USERNAME_KEY = "Username"
 AUTH_PASSWORD_KEY = "Pw"
 
 # query param constants
-MP3_STREAM = "stream.mp3?static=true"
+AUDIO_STREAM = "stream.mp3"
 API_KEY = "api_key="
 
 
@@ -106,7 +106,7 @@ class EmbyClient(object):
     def get_song_file(self, song_id):
         url = '{0}{1}/{2}/{3}&{4}{5}'\
             .format(self.host, SONG_FILE_URL,
-                    song_id, MP3_STREAM, API_KEY, self.auth.token)
+                    song_id, AUDIO_STREAM, API_KEY, self.auth.token)
         return url
 
     def get_albums_by_artist(self, artist_id):

--- a/emby_client.py
+++ b/emby_client.py
@@ -104,7 +104,7 @@ class EmbyClient(object):
         return self._get(instant_item_mix)
 
     def get_song_file(self, song_id):
-        url = '{0}{1}/{2}/{3}&{4}{5}'\
+        url = '{0}{1}/{2}/{3}?{4}{5}'\
             .format(self.host, SONG_FILE_URL,
                     song_id, AUDIO_STREAM, API_KEY, self.auth.token)
         return url
@@ -194,9 +194,11 @@ class MediaItemType(Enum):
     ARTIST = "MusicArtist"
     ALBUM = "MusicAlbum"
     SONG = "Audio"
+    OTHER = "Other"
 
     @staticmethod
     def from_string(enum_string):
         for item_type in MediaItemType:
             if item_type.value == enum_string:
                 return item_type
+        return OTHER

--- a/emby_croft.py
+++ b/emby_croft.py
@@ -240,7 +240,7 @@ class EmbyCroft(object):
                 elif result.type == MediaItemType.SONG:
                     songs.append(result)
                 else:
-                    logging.log(20, "Item is not an Artist/Album/Song: " + result.type)
+                    logging.log(20, "Item is not an Artist/Album/Song: " + result.type.value)
 
             if artists:
                 artist_songs = self.get_songs_by_artist(artists[0].id)


### PR DESCRIPTION
don't use static=true, because if the media library contains non-mp3 types, they won't get transcoded. They still get the .mp3 extension, however, so vlc (or any other backend) really doesn't know what to do with them.

This PR also fixes an issue where results that are not artists, albums, or songs causes the emby plugin to crash.