### PR TITLE
Handling for streaming non-mp3 files

### DIFF
--- a/emby_client.py
+++ b/emby_client.py
@@ -24,7 +24,7 @@ AUTH_USERNAME_KEY = "Username"
 AUTH_PASSWORD_KEY = "Pw"
 
 # query param constants
-AUDIO_STREAM = "stream.mp3"
+AUDIO_STREAM = "universal"
 API_KEY = "api_key="
 
 
@@ -127,9 +127,9 @@ class EmbyClient(PublicEmbyClient):
         return self._get(instant_item_mix)
 
     def get_song_file(self, song_id):
-        url = '{0}{1}/{2}/{3}?{4}{5}'\
+        url = '{0}{1}/{2}/{3}?userId={4}&MaxStreamingBitrate=140000000&AudioCodec=mp3'\
             .format(self.host, SONG_FILE_URL,
-                    song_id, AUDIO_STREAM, API_KEY, self.auth.token)
+                    song_id, AUDIO_STREAM, self.auth.user_id)
         return url
 
     def get_albums_by_artist(self, artist_id):


### PR DESCRIPTION
Current behavior hard-codes the stream.mp3 request handler, which does not work for non-mp3 source files unless the server is already set to transcode to mp3. Neither the local nor vlc picroft audio backends support container detection, so the generalized stream legacy handler does not work. This commit changes the request URI to use the current swagger spec, which supports transcoding requests in the URI args; it is hardcoded to mp3 because picroft's local audio backend has a limited number of containers supported.

Since current swagger spec requires user_id in the stream handler and since the skill appears to be using both user auth and token auth, the token was replaced with the user_id to minimize things that can go wrong.